### PR TITLE
fix installation error on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Imports:
     methods,
     Rcpp,
     grid
+Biarch: true
 NeedsCompilation: yes
 RcppModules: bvarm_module, bvars_module,
              bvarcnw_module, bvarinw_module,


### PR DESCRIPTION
Possible fix to the *configure.win* installation error on Windows. Builds the package on i386. Works on Windows 10 and Ubuntu 18.04 using R 3.6.1.